### PR TITLE
Set default_runtime_name to the runtime to be used

### DIFF
--- a/src/containerd.go
+++ b/src/containerd.go
@@ -331,6 +331,13 @@ func UpdateV1Config(config *toml.Tree) error {
 		"options",
 	}
 
+	defaultRuntimeNamePath := []string{
+		"plugins",
+		"cri",
+		"containerd",
+		"default_runtime_name",
+	}
+
 	switch runc := config.GetPath(runcPath).(type) {
 	case *toml.Tree:
 		runc, _ = toml.Load(runc.String())
@@ -351,6 +358,7 @@ func UpdateV1Config(config *toml.Tree) error {
 			config.SetPath(append(defaultRuntimePath, "privileged_without_host_devices"), false)
 		}
 		config.SetPath(append(defaultRuntimeOptionsPath, "Runtime"), runtimePath)
+		config.SetPath(defaultRuntimeNamePath, runtimeClassFlag)
 	}
 
 	return nil
@@ -379,7 +387,15 @@ func RevertV1Config(config *toml.Tree) error {
 		"options",
 	}
 
+	defaultRuntimeNamePath := []string{
+		"plugins",
+		"cri",
+		"containerd",
+		"default_runtime_name",
+	}
+
 	config.DeletePath(runtimeClassPath)
+	config.DeletePath(defaultRuntimeNamePath)
 	if runtime, ok := config.GetPath(append(defaultRuntimeOptionsPath, "Runtime")).(string); ok {
 		if RuntimeBinary == path.Base(runtime) {
 			config.DeletePath(append(defaultRuntimeOptionsPath, "Runtime"))
@@ -464,6 +480,12 @@ func UpdateV2Config(config *toml.Tree) error {
 		runtimeClassFlag,
 		"options",
 	}
+	defaultRuntimeNamePath := []string{
+		"plugins",
+		"io.containerd.grpc.v1.cri",
+		"containerd",
+		"default_runtime_name",
+	}
 
 	switch runc := config.GetPath(runcPath).(type) {
 	case *toml.Tree:
@@ -479,6 +501,7 @@ func UpdateV2Config(config *toml.Tree) error {
 
 	if setAsDefaultFlag {
 		config.SetPath(append(containerdPath, "default_runtime_name"), runtimeClassFlag)
+		config.SetPath(defaultRuntimeNamePath, runtimeClassFlag)
 	}
 
 	return nil
@@ -498,8 +521,15 @@ func RevertV2Config(config *toml.Tree) error {
 		"runtimes",
 		runtimeClassFlag,
 	}
+	defaultRuntimeNamePath := []string{
+		"plugins",
+		"io.containerd.grpc.v1.cri",
+		"containerd",
+		"default_runtime_name",
+	}
 
 	config.DeletePath(runtimeClassPath)
+	config.DeletePath(defaultRuntimeNamePath)
 	if runtime, ok := config.GetPath(append(containerdPath, "default_runtime_name")).(string); ok {
 		if runtimeClassFlag == runtime {
 			config.DeletePath(append(containerdPath, "default_runtime_name"))


### PR DESCRIPTION
There was an [issue](https://github.com/NVIDIA/gpu-operator/issues/143) in gpu operator where the `nvidia-device-plugin` pod was failing to start when `containerd` was used. On further inspection, we found that containerd 1.3 added a new [property](https://github.com/containerd/containerd/blob/2adb2ea64c5aa7aea327844c84d56cf397a34f87/pkg/cri/config/config.go#L65) called `default_runtime_name` which sets the default runtime. Since this is not set when using gpu operator, it defaults to `runc`, and thus fails. This pr sets default_runtime_name to `nvidia` to use nvidia container runtime.